### PR TITLE
Reduce layout shifts with placeholders and skeletons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,7 @@ import { Category, Product } from "@/types";
 import apiClient from "@/lib/api";
 import { toast } from "sonner";
 import RelativeTime from "@/components/layout/time-ago";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const categoryIcons = {
   pizza: Pizza, utensils: UtensilsCrossed, chefhat: ChefHat, leaf: Leaf, cake: Cake,
@@ -72,6 +73,7 @@ const testimonials = [
 export default function HomePage() {
   const [recommendedProducts, setRecommendedProducts] = useState<Product[]>([]);
   const [popularCategories, setPopularCategories] = useState<Category[]>();
+  const [loadingRecs, setLoadingRecs] = useState(true);
 
   useEffect(() => {
     const fetchPopularCategories = async () => {
@@ -98,7 +100,7 @@ export default function HomePage() {
         }
 
         const settled = await Promise.allSettled(
-            categories.map((c) => apiClient.getActiveRecommendation({ category_id: c.id }))
+          categories.map((c) => apiClient.getActiveRecommendation({ category_id: c.id }))
         );
 
         const prods: Product[] = [];
@@ -122,6 +124,8 @@ export default function HomePage() {
         console.error(e);
         toast.error('Eroare la încărcarea produselor recomandate');
         setRecommendedProducts([]);
+      } finally {
+        setLoadingRecs(false);
       }
     };
 
@@ -281,46 +285,56 @@ export default function HomePage() {
           )}
 
           {/* Recommended Products */}
-          {recommendedProducts.length > 0 && (
-              <section className="py-16 min-h-[40vh] bg-muted/20" aria-labelledby="recommended-heading">
-                <div className="container mx-auto px-4">
-                  <header className="text-center mb-12">
-                    <div className="flex items-center justify-center space-x-2 mb-4">
-                      <Star className="w-6 h-6 text-[hsl(var(--accent))] fill-current" aria-hidden="true" />
-                      <h2 id="recommended-heading" className="text-3xl lg:text-4xl font-bold">
-                        Preparate <span className="text-[hsl(var(--accent))]">recomandate</span>
-                      </h2>
-                      <Star className="w-6 h-6 text-[hsl(var(--accent))] fill-current" aria-hidden="true" />
-                    </div>
-                    <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-                      Preparatele noastre cele mai apreciate, selectate special pentru tine
-                    </p>
-                  </header>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12" role="list">
-                    {recommendedProducts.map((product) => (
-                        <article key={product.id} role="listitem">
-                          <ProductCard
-                              product={product}
-                              showCategory
-                              className="animate-fade-in"
-                          />
-                        </article>
-                    ))}
-                  </div>
-
-                  <div className="text-center">
-                    <Button asChild size="lg" className="bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--primary))]/80 hover:from-[hsl(var(--primary))]/90 hover:to-[hsl(var(--primary))]/70">
-                      <Link href="/meniu" aria-describedby="all-products-description">
-                        Vezi toate preparatele
-                        <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
-                      </Link>
-                    </Button>
-                    <span id="all-products-description" className="sr-only">Accesează meniul complet cu toate preparatele disponibile</span>
-                  </div>
+          <section className="py-16 min-h-[40vh] bg-muted/20" aria-labelledby="recommended-heading">
+            <div className="container mx-auto px-4">
+              <header className="text-center mb-12">
+                <div className="flex items-center justify-center space-x-2 mb-4">
+                  <Star className="w-6 h-6 text-[hsl(var(--accent))] fill-current" aria-hidden="true" />
+                  <h2 id="recommended-heading" className="text-3xl lg:text-4xl font-bold">
+                    Preparate <span className="text-[hsl(var(--accent))]">recomandate</span>
+                  </h2>
+                  <Star className="w-6 h-6 text-[hsl(var(--accent))] fill-current" aria-hidden="true" />
                 </div>
-              </section>
-          )}
+                <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
+                  Preparatele noastre cele mai apreciate, selectate special pentru tine
+                </p>
+              </header>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12" role="list">
+                {loadingRecs ? (
+                  Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-[350px] w-full rounded-lg" />
+                  ))
+                ) : recommendedProducts.length > 0 ? (
+                  recommendedProducts.map((product) => (
+                    <article key={product.id} role="listitem">
+                      <ProductCard
+                        product={product}
+                        showCategory
+                        className="animate-fade-in"
+                      />
+                    </article>
+                  ))
+                ) : (
+                  <p className="text-center col-span-full text-muted-foreground">
+                    Momentan nu există preparate recomandate.
+                  </p>
+                )}
+              </div>
+
+              {recommendedProducts.length > 0 && (
+                <div className="text-center">
+                  <Button asChild size="lg" className="bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--primary))]/80 hover:from-[hsl(var(--primary))]/90 hover:to-[hsl(var(--primary))]/70">
+                    <Link href="/meniu" aria-describedby="all-products-description">
+                      Vezi toate preparatele
+                      <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
+                    </Link>
+                  </Button>
+                  <span id="all-products-description" className="sr-only">Accesează meniul complet cu toate preparatele disponibile</span>
+                </div>
+              )}
+            </div>
+          </section>
 
           {/* Testimonials */}
           <section className="py-16 bg-muted/20">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -117,74 +117,76 @@ export function Header() {
               </Button>
 
               {/* User icon + dropdown (desktop) */}
-              {mounted && !loading && (
-                  <DropdownMenu open={userMenuOpen} onOpenChange={setUserMenuOpen}>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                          variant="ghost"
-                          size="icon"
-                          className="w-9 h-9"
-                          onMouseEnter={openNow}
-                          onMouseLeave={closeSoon}
-                          aria-label="Meniu utilizator"
-                      >
-                        <UserIcon className="w-4 h-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-
-                    <DropdownMenuContent
-                        align="center"
-                        sideOffset={-5}
-                        onMouseEnter={openNow}
-                        onMouseLeave={closeSoon}
-                        className="w-56"
+              {mounted && !loading ? (
+                <DropdownMenu open={userMenuOpen} onOpenChange={setUserMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="w-9 h-9"
+                      onMouseEnter={openNow}
+                      onMouseLeave={closeSoon}
+                      aria-label="Meniu utilizator"
                     >
-                      {user ? (
-                          <>
-                            <DropdownMenuLabel className="truncate">
-                              {user.name || user.email}
-                            </DropdownMenuLabel>
-                            <DropdownMenuSeparator />
-                            <Link href="/account">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Contul meu
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/account/orders">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Comenzile mele
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/account/addresses">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Adresele mele
-                              </DropdownMenuItem>
-                            </Link>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onClick={() => logout()}
-                            >
-                              <LogOut className="w-4 h-4 mr-2" />
-                              Delogare
-                            </DropdownMenuItem>
-                          </>
-                      ) : (
-                          <>
-                            <Link href="/auth/login">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Autentificare
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/auth/register">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Înregistrare
-                              </DropdownMenuItem>
-                            </Link>
-                          </>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                      <UserIcon className="w-4 h-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+
+                  <DropdownMenuContent
+                    align="center"
+                    sideOffset={-5}
+                    onMouseEnter={openNow}
+                    onMouseLeave={closeSoon}
+                    className="w-56"
+                  >
+                    {user ? (
+                      <>
+                        <DropdownMenuLabel className="truncate">
+                          {user.name || user.email}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <Link href="/account">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Contul meu
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/account/orders">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Comenzile mele
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/account/addresses">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Adresele mele
+                          </DropdownMenuItem>
+                        </Link>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => logout()}
+                        >
+                          <LogOut className="w-4 h-4 mr-2" />
+                          Delogare
+                        </DropdownMenuItem>
+                      </>
+                    ) : (
+                      <>
+                        <Link href="/auth/login">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Autentificare
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/auth/register">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Înregistrare
+                          </DropdownMenuItem>
+                        </Link>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <div className="w-9 h-9" aria-hidden="true" />
               )}
 
               {/* Cart */}


### PR DESCRIPTION
## Summary
- reserve space for recommended products with skeleton placeholders
- add placeholder in header for user dropdown to avoid shifts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68aadf25565083298ce9739546137689