### PR TITLE
Reduce layout shifts with placeholders and skeletons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,7 +75,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,10 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
 import { ThemeProvider } from '@/providers/theme-provider';
 import { Toaster } from 'sonner';
 import { AuthProvider } from "@/contexts/auth-context";
 import Script from "next/script"
 import {generatePageMetadata} from "@/utils/generate-metadata";
-
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  preload: true,
-  variable: "--font-inter",
-  adjustFontFallback: true,
-  fallback: ["system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto", "Arial", "sans-serif"],
-  weight: ["400", "500", "600", "700", "900"],
-})
 
 // Enhanced viewport configuration
 export const viewport: Viewport = {
@@ -51,12 +40,6 @@ export default function RootLayout({
       <html lang="ro" suppressHydrationWarning>
       <head>
         {/* Preconnect to external domains for performance */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-              href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
-              rel="stylesheet"
-          />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
 
         {/* DNS prefetch for external resources */}
@@ -71,7 +54,7 @@ export default function RootLayout({
         {/* Performance hints */}
         <link rel="preload" href="/hero.jpeg" as="image" type="image/jpeg" fetchPriority="high" />
       </head>
-      <body className={inter.className}>
+      <body className="font-sans">
       <AuthProvider>
         <ThemeProvider
             attribute="class"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -117,74 +117,76 @@ export function Header() {
               </Button>
 
               {/* User icon + dropdown (desktop) */}
-              {mounted && !loading && (
-                  <DropdownMenu open={userMenuOpen} onOpenChange={setUserMenuOpen}>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                          variant="ghost"
-                          size="icon"
-                          className="w-9 h-9"
-                          onMouseEnter={openNow}
-                          onMouseLeave={closeSoon}
-                          aria-label="Meniu utilizator"
-                      >
-                        <UserIcon className="w-4 h-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-
-                    <DropdownMenuContent
-                        align="center"
-                        sideOffset={-5}
-                        onMouseEnter={openNow}
-                        onMouseLeave={closeSoon}
-                        className="w-56"
+              {mounted && !loading ? (
+                <DropdownMenu open={userMenuOpen} onOpenChange={setUserMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="w-9 h-9"
+                      onMouseEnter={openNow}
+                      onMouseLeave={closeSoon}
+                      aria-label="Meniu utilizator"
                     >
-                      {user ? (
-                          <>
-                            <DropdownMenuLabel className="truncate">
-                              {user.name || user.email}
-                            </DropdownMenuLabel>
-                            <DropdownMenuSeparator />
-                            <Link href="/account">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Contul meu
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/account/orders">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Comenzile mele
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/account/addresses">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Adresele mele
-                              </DropdownMenuItem>
-                            </Link>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onClick={() => logout()}
-                            >
-                              <LogOut className="w-4 h-4 mr-2" />
-                              Delogare
-                            </DropdownMenuItem>
-                          </>
-                      ) : (
-                          <>
-                            <Link href="/auth/login">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Autentificare
-                              </DropdownMenuItem>
-                            </Link>
-                            <Link href="/auth/register">
-                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                                Înregistrare
-                              </DropdownMenuItem>
-                            </Link>
-                          </>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                      <UserIcon className="w-4 h-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+
+                  <DropdownMenuContent
+                    align="center"
+                    sideOffset={-5}
+                    onMouseEnter={openNow}
+                    onMouseLeave={closeSoon}
+                    className="w-56"
+                  >
+                    {user ? (
+                      <>
+                        <DropdownMenuLabel className="truncate">
+                          {user.name || user.email}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <Link href="/account">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Contul meu
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/account/orders">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Comenzile mele
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/account/addresses">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Adresele mele
+                          </DropdownMenuItem>
+                        </Link>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => logout()}
+                        >
+                          <LogOut className="w-4 h-4 mr-2" />
+                          Delogare
+                        </DropdownMenuItem>
+                      </>
+                    ) : (
+                      <>
+                        <Link href="/auth/login">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Autentificare
+                          </DropdownMenuItem>
+                        </Link>
+                        <Link href="/auth/register">
+                          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                            Înregistrare
+                          </DropdownMenuItem>
+                        </Link>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <div className="w-9 h-9" aria-hidden="true" />
               )}
 
               {/* Cart */}


### PR DESCRIPTION
## Summary
- refine recommended products skeleton to match final card size and reserve vertical space
- remove external Inter font in favor of system font to avoid build-time fetch and font shifts
- apply system font globally

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_TELEMETRY_DISABLED=1 npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aadf25565083298ce9739546137689